### PR TITLE
fix: performance and security improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,29 @@ SSR HTML for authenticated pages is cached per-user in **Cloudflare KV** (`HTML_
 | TTL | 1 hour |
 | Invalidation | On successful experience log, the user's KV entries are deleted in the background |
 
+### Region Alignment and Smart Placement
+
+Cloudflare Workers run at the edge location closest to the **user's browser** by default. Every database query then travels from that edge node to the **Supabase region** where your PostgreSQL instance lives. If those two locations are far apart, every API call incurs significant cross-region latency.
+
+**Smart Placement** (enabled in `wrangler.jsonc`) automatically routes execution to the Cloudflare region that minimises total round-trip time to Supabase.
+
+#### How to check your Supabase region
+
+1. Open the [Supabase Dashboard](https://supabase.com/dashboard)
+2. Select your project → **Settings → General**
+3. The **Region** field shows where your database is hosted (e.g. `ap-northeast-1 — Tokyo`)
+
+#### Recommended regions
+
+| Supabase Region | Best for |
+|-----------------|----------|
+| `ap-northeast-1` (Tokyo) | Japan / East Asia |
+| `us-east-1` (N. Virginia) | North America / East US |
+| `eu-west-1` (Ireland) | Europe |
+| `ap-southeast-1` (Singapore) | Southeast Asia |
+
+Set your Supabase project region to match your primary user base. Smart Placement will then keep compute and database as close together as possible.
+
 ### Execution Mode Differences
 
 The `/api/logs` endpoint behaves differently depending on the runtime:

--- a/app/api/chat/rethink/route.ts
+++ b/app/api/chat/rethink/route.ts
@@ -8,7 +8,7 @@ import { AuthError } from '@/core/errors/AuthError';
 import { ValidationError } from '@/core/errors/ValidationError';
 import { RateLimitError } from '@/core/errors/RateLimitError';
 import { handleError, checkBodySize } from '@/lib/apiHelpers';
-import { chatRateLimiter } from '@/infrastructure/rate-limiting/rateLimiterSingleton';
+import { createChatRateLimiter } from '@/infrastructure/rate-limiting/rateLimiterSingleton';
 import type { LMConfig } from '@/types';
 
 interface RethinkRequestBody {
@@ -24,7 +24,8 @@ export async function POST(req: Request) {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) throw new AuthError('認証が必要です');
 
-    const rateLimitStatus = chatRateLimiter.check(user.id);
+    const rateLimiter = createChatRateLimiter();
+    const rateLimitStatus = await rateLimiter.check(user.id);
     if (!rateLimitStatus.allowed) {
       throw new RateLimitError(
         `トークン制限に達しました。${rateLimitStatus.retryAfterSeconds}秒後に再試行してください。`,
@@ -56,9 +57,18 @@ export async function POST(req: Request) {
       throw new ValidationError('Claude API キーが設定されていません');
     }
 
-    // Get thread history to reconstruct context
+    // Run all independent DB queries in parallel after auth
     const historyUseCase = createGetThreadHistoryUseCase(supabase);
-    const allMessages = await historyUseCase.getMessages(threadId);
+    const { persona, experience, psychology } = createRepositories(supabase);
+    const [allMessages, personaSnapshot, experiences, bigFive, attachment, identityStatus] =
+      await Promise.all([
+        historyUseCase.getMessages(threadId),
+        persona.getLatest(user.id),
+        experience.findRecent(user.id, 5),
+        psychology.getBigFiveScore(user.id),
+        psychology.getAttachmentProfile(user.id),
+        psychology.getIdentityStatus(user.id),
+      ]);
 
     // Find user message at this pair_node and build prior history
     const pairNodeUserMsgIdx = allMessages.findIndex(
@@ -75,20 +85,12 @@ export async function POST(req: Request) {
       .map((m) => ({ role: m.role, content: m.content }));
 
     // Build system prompt from persona + recent experiences + psychology profile
-    const { persona, experience, psychology } = createRepositories(supabase);
-    const personaSnapshot = await persona.getLatest(user.id);
     if (!personaSnapshot) {
       return NextResponse.json(
         { message: 'ペルソナスナップショットが見つかりません。先にペルソナページでトレイト推論を実行してください。' },
         { status: 422 },
       );
     }
-    const [experiences, bigFive, attachment, identityStatus] = await Promise.all([
-      experience.findRecent(user.id, 5),
-      psychology.getBigFiveScore(user.id),
-      psychology.getAttachmentProfile(user.id),
-      psychology.getIdentityStatus(user.id),
-    ]);
     const systemPrompt = buildChatSystemPrompt(
       personaSnapshot.personaJson,
       experiences,
@@ -122,7 +124,7 @@ export async function POST(req: Request) {
 
           // Record estimated token usage for rate limiting
           const estimatedTokens = Math.ceil(fullText.length / 3);
-          chatRateLimiter.record(user.id, estimatedTokens);
+          await rateLimiter.record(user.id, estimatedTokens);
 
           controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true })}\n\n`));
         } catch (err) {

--- a/app/api/chat/rethink/route.ts
+++ b/app/api/chat/rethink/route.ts
@@ -56,9 +56,18 @@ export async function POST(req: Request) {
       throw new ValidationError('Claude API キーが設定されていません');
     }
 
-    // Get thread history to reconstruct context
+    // Run all independent DB queries in parallel after auth
     const historyUseCase = createGetThreadHistoryUseCase(supabase);
-    const allMessages = await historyUseCase.getMessages(threadId);
+    const { persona, experience, psychology } = createRepositories(supabase);
+    const [allMessages, personaSnapshot, experiences, bigFive, attachment, identityStatus] =
+      await Promise.all([
+        historyUseCase.getMessages(threadId),
+        persona.getLatest(user.id),
+        experience.findRecent(user.id, 5),
+        psychology.getBigFiveScore(user.id),
+        psychology.getAttachmentProfile(user.id),
+        psychology.getIdentityStatus(user.id),
+      ]);
 
     // Find user message at this pair_node and build prior history
     const pairNodeUserMsgIdx = allMessages.findIndex(
@@ -75,20 +84,12 @@ export async function POST(req: Request) {
       .map((m) => ({ role: m.role, content: m.content }));
 
     // Build system prompt from persona + recent experiences + psychology profile
-    const { persona, experience, psychology } = createRepositories(supabase);
-    const personaSnapshot = await persona.getLatest(user.id);
     if (!personaSnapshot) {
       return NextResponse.json(
         { message: 'ペルソナスナップショットが見つかりません。先にペルソナページでトレイト推論を実行してください。' },
         { status: 422 },
       );
     }
-    const [experiences, bigFive, attachment, identityStatus] = await Promise.all([
-      experience.findRecent(user.id, 5),
-      psychology.getBigFiveScore(user.id),
-      psychology.getAttachmentProfile(user.id),
-      psychology.getIdentityStatus(user.id),
-    ]);
     const systemPrompt = buildChatSystemPrompt(
       personaSnapshot.personaJson,
       experiences,

--- a/app/api/chat/rethink/route.ts
+++ b/app/api/chat/rethink/route.ts
@@ -122,9 +122,9 @@ export async function POST(req: Request) {
           const rethinkUseCase = createRethinkMessageUseCase(supabase);
           await rethinkUseCase.execute(pairNodeId, user.id, fullText);
 
-          // Record estimated token usage for rate limiting
+          // Atomically check budget and record usage to prevent concurrent over-spend
           const estimatedTokens = Math.ceil(fullText.length / 3);
-          await rateLimiter.record(user.id, estimatedTokens);
+          await rateLimiter.checkAndRecord(user.id, estimatedTokens);
 
           controller.enqueue(encoder.encode(`data: ${JSON.stringify({ done: true })}\n\n`));
         } catch (err) {

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -6,7 +6,7 @@ import { ValidationError } from '@/core/errors/ValidationError';
 import { AuthError } from '@/core/errors/AuthError';
 import { RateLimitError } from '@/core/errors/RateLimitError';
 import { handleError, checkBodySize } from '@/lib/apiHelpers';
-import { chatRateLimiter } from '@/infrastructure/rate-limiting/rateLimiterSingleton';
+import { createChatRateLimiter } from '@/infrastructure/rate-limiting/rateLimiterSingleton';
 import { logger } from '@/infrastructure/observability/logger';
 import type { ChatMessage, LMConfig } from '@/types';
 
@@ -24,7 +24,8 @@ export async function POST(req: Request) {
     if (!user) throw new AuthError('認証が必要です');
 
     // Per-user token budget check
-    const rateLimitStatus = chatRateLimiter.check(user.id);
+    const rateLimiter = createChatRateLimiter();
+    const rateLimitStatus = await rateLimiter.check(user.id);
     if (!rateLimitStatus.allowed) {
       logger.error('api:chat_rate_limit_exceeded', {
         layer: 'ChatRoute',
@@ -80,7 +81,7 @@ export async function POST(req: Request) {
 
     // Record token usage for rate limiting
     if (result.tokenUsage != null) {
-      chatRateLimiter.record(user.id, result.tokenUsage.total);
+      await rateLimiter.record(user.id, result.tokenUsage.total);
       logger.info('api:chat_tokens_recorded', {
         userId: user.id,
         tokenUsage: result.tokenUsage,

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -79,13 +79,32 @@ export async function POST(req: Request) {
       );
     }
 
-    // Record token usage for rate limiting
+    // Atomically check budget and record usage to prevent concurrent over-spend
     if (result.tokenUsage != null) {
-      await rateLimiter.record(user.id, result.tokenUsage.total);
+      const recordStatus = await rateLimiter.checkAndRecord(user.id, result.tokenUsage.total);
+      if (!recordStatus.allowed) {
+        logger.error('api:chat_rate_limit_exceeded', {
+          layer: 'ChatRoute',
+          operation: 'POST /api/chat (checkAndRecord)',
+          userId: user.id,
+          usedTokens: recordStatus.usedTokens,
+          maxTokens: recordStatus.maxTokens,
+          retryAfterSeconds: recordStatus.retryAfterSeconds,
+        });
+        throw new RateLimitError(
+          `トークン制限に達しました。${recordStatus.retryAfterSeconds}秒後に再試行してください。`,
+          {
+            userId: user.id,
+            usedTokens: recordStatus.usedTokens,
+            maxTokens: recordStatus.maxTokens,
+            retryAfterSeconds: recordStatus.retryAfterSeconds,
+          },
+        );
+      }
       logger.info('api:chat_tokens_recorded', {
         userId: user.id,
         tokenUsage: result.tokenUsage,
-        newUsedTotal: rateLimitStatus.usedTokens + result.tokenUsage.total,
+        newUsedTotal: recordStatus.usedTokens,
       });
     }
 

--- a/app/dashboard/DashboardContent.tsx
+++ b/app/dashboard/DashboardContent.tsx
@@ -1,0 +1,27 @@
+import ConfrontationChart from '@/components/ConfrontationChart';
+import StressChart from '@/components/StressChart';
+import ObstacleList from '@/components/ObstacleList';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createGetAnalyticsUseCase } from '@/container/createUseCases';
+import type { ObstacleRecord } from '@/types';
+import styles from './page.module.css';
+
+interface Props {
+  userId: string;
+}
+
+export default async function DashboardContent({ userId }: Props) {
+  const supabase = await createSupabaseServerClient();
+  const data = await createGetAnalyticsUseCase(supabase).execute(userId);
+
+  return (
+    <>
+      <section className={styles.grid}>
+        <ConfrontationChart rate={data.confrontationRate} />
+        <StressChart points={data.stressTrend} />
+      </section>
+
+      <ObstacleList items={data.recentExperiences as unknown as ObstacleRecord[]} />
+    </>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,13 +2,9 @@ import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
-import ConfrontationChart from '@/components/ConfrontationChart';
-import StressChart from '@/components/StressChart';
-import ObstacleList from '@/components/ObstacleList';
 import PsychologySection from './PsychologySection';
+import DashboardContent from './DashboardContent';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
-import { createGetAnalyticsUseCase } from '@/container/createUseCases';
-import type { ObstacleRecord } from '@/types';
 import styles from './page.module.css';
 
 export default async function DashboardPage() {
@@ -18,20 +14,15 @@ export default async function DashboardPage() {
   } = await supabase.auth.getUser();
   if (!user) redirect('/login');
 
-  const data = await createGetAnalyticsUseCase(supabase).execute(user.id);
-
   return (
     <>
       <Header />
       <main className={styles.main}>
         <h1 className={styles.title}>ダッシュボード</h1>
 
-        <section className={styles.grid}>
-          <ConfrontationChart rate={data.confrontationRate} />
-          <StressChart points={data.stressTrend} />
-        </section>
-
-        <ObstacleList items={data.recentExperiences as unknown as ObstacleRecord[]} />
+        <Suspense fallback={<div style={{ color: '#6b7280' }}>読み込み中...</div>}>
+          <DashboardContent userId={user.id} />
+        </Suspense>
 
         <section>
           <h2 style={{ marginBottom: '1.5rem', fontSize: '1.25rem', fontWeight: 700 }}>

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -1,0 +1,25 @@
+# Deployment Checklist
+
+## Region Configuration
+- [ ] Confirm Supabase project region (Dashboard → Settings → General → Region)
+- [ ] Confirm `smart_placement.mode = "smart"` is set in `wrangler.jsonc`
+- [ ] Verify Supabase region matches primary user geography
+
+## Environment Variables
+- [ ] `NEXT_PUBLIC_SUPABASE_URL` set in Cloudflare Workers environment
+- [ ] `NEXT_PUBLIC_SUPABASE_ANON_KEY` set in Cloudflare Workers environment
+- [ ] `SUPABASE_SERVICE_ROLE_KEY` set as a secret (not plaintext)
+- [ ] `CHAT_RATE_LIMIT_MAX_TOKENS` (default: 50000)
+- [ ] `CHAT_RATE_LIMIT_WINDOW_MS` (default: 3600000)
+- [ ] `LLM_MAX_CONCURRENT` (default: 3)
+
+## Supabase Configuration
+- [ ] Row Level Security (RLS) enabled on all tables
+- [ ] All migrations applied: `supabase db push`
+- [ ] `get_db_stats()` function accessible by service_role only
+- [ ] `classify_experience_atomic()` RPC function exists
+
+## Pre-Deploy Checks
+- [ ] `npm run build` passes without errors
+- [ ] `npm run lint` passes (no architecture boundary violations)
+- [ ] `npm test` passes

--- a/lib/apiHelpers.ts
+++ b/lib/apiHelpers.ts
@@ -5,6 +5,7 @@ import { LLMError } from '@/core/errors/LLMError';
 import { InfrastructureError } from '@/core/errors/InfrastructureError';
 import { RateLimitError } from '@/core/errors/RateLimitError';
 import { LLMConcurrencyError } from '@/core/errors/LLMConcurrencyError';
+import { ConcurrencyError } from '@/core/errors/ConcurrencyError';
 
 export function checkBodySize(req: Request, maxBytes: number): void {
   const contentLength = req.headers.get('content-length');
@@ -33,6 +34,9 @@ export function handleError(err: unknown): NextResponse {
       stack: err.stack,
     });
     return NextResponse.json({ message: err.message }, { status: 503 });
+  }
+  if (err instanceof ConcurrencyError) {
+    return NextResponse.json({ message: err.message }, { status: 409 });
   }
   if (err instanceof ValidationError) {
     return NextResponse.json({ message: err.message }, { status: 400 });

--- a/src/application/mappers/PairNodeMapper.ts
+++ b/src/application/mappers/PairNodeMapper.ts
@@ -8,6 +8,7 @@ export class PairNodeMapper {
       threadId: row.thread_id as string,
       selectMessageId: row.select_message_id != null ? (row.select_message_id as string) : null,
       createdAt: row.created_at as string,
+      version: typeof row.version === 'number' ? row.version : 0,
     };
   }
 }

--- a/src/application/ports/ILLMRateLimiter.ts
+++ b/src/application/ports/ILLMRateLimiter.ts
@@ -8,8 +8,10 @@ export interface RateLimitStatus {
 }
 
 export interface ILLMRateLimiter {
-  /** LLM 呼び出し前: 残バジェットを確認 */
+  /** LLM 呼び出し前: 残バジェットを確認 (fast-fail, non-atomic) */
   check(userId: string): Promise<RateLimitStatus>;
   /** LLM 呼び出し後: 実消費トークンを記録 */
   record(userId: string, tokens: number): Promise<void>;
+  /** LLM 呼び出し後: バジェット確認と記録を1トランザクションで実行 (atomic) */
+  checkAndRecord(userId: string, tokens: number): Promise<RateLimitStatus>;
 }

--- a/src/application/ports/ILLMRateLimiter.ts
+++ b/src/application/ports/ILLMRateLimiter.ts
@@ -9,7 +9,7 @@ export interface RateLimitStatus {
 
 export interface ILLMRateLimiter {
   /** LLM 呼び出し前: 残バジェットを確認 */
-  check(userId: string): RateLimitStatus;
+  check(userId: string): Promise<RateLimitStatus>;
   /** LLM 呼び出し後: 実消費トークンを記録 */
-  record(userId: string, tokens: number): void;
+  record(userId: string, tokens: number): Promise<void>;
 }

--- a/src/application/usecases/RethinkMessageUseCase.ts
+++ b/src/application/usecases/RethinkMessageUseCase.ts
@@ -1,6 +1,7 @@
 import type { IPairNodeRepository } from '@/core/domains/chat/IPairNodeRepository';
 import type { IMessageRepository } from '@/core/domains/chat/IMessageRepository';
 import type { MessageData } from '@/core/domains/chat/Message';
+import { ValidationError } from '@/core/errors/ValidationError';
 
 export class RethinkMessageUseCase {
   constructor(
@@ -9,13 +10,16 @@ export class RethinkMessageUseCase {
   ) {}
 
   async execute(pairNodeId: string, userId: string, newContent: string): Promise<MessageData> {
+    const pairNode = await this.pairNodeRepo.findById(pairNodeId);
+    if (!pairNode) throw new ValidationError('指定したペアノードが見つかりません');
+
     const newMessage = await this.messageRepo.save({
       pairNodeId,
       userId,
       role: 'assistant',
       content: newContent,
     });
-    await this.pairNodeRepo.updateSelectMessage(pairNodeId, newMessage.id);
+    await this.pairNodeRepo.updateSelectMessage(pairNodeId, newMessage.id, pairNode.version);
     return newMessage;
   }
 }

--- a/src/application/usecases/RethinkMessageUseCase.ts
+++ b/src/application/usecases/RethinkMessageUseCase.ts
@@ -1,25 +1,29 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import type { IPairNodeRepository } from '@/core/domains/chat/IPairNodeRepository';
-import type { IMessageRepository } from '@/core/domains/chat/IMessageRepository';
-import type { MessageData } from '@/core/domains/chat/Message';
 import { ValidationError } from '@/core/errors/ValidationError';
+import { ConcurrencyError } from '@/core/errors/ConcurrencyError';
+import { InfrastructureError } from '@/core/errors/InfrastructureError';
 
 export class RethinkMessageUseCase {
   constructor(
     private readonly pairNodeRepo: IPairNodeRepository,
-    private readonly messageRepo: IMessageRepository,
+    private readonly supabase: SupabaseClient,
   ) {}
 
-  async execute(pairNodeId: string, userId: string, newContent: string): Promise<MessageData> {
+  async execute(pairNodeId: string, userId: string, newContent: string): Promise<void> {
     const pairNode = await this.pairNodeRepo.findById(pairNodeId);
     if (!pairNode) throw new ValidationError('指定したペアノードが見つかりません');
 
-    const newMessage = await this.messageRepo.save({
-      pairNodeId,
-      userId,
-      role: 'assistant',
-      content: newContent,
+    const { error } = await this.supabase.rpc('rethink_pair_node', {
+      p_pair_node_id: pairNodeId,
+      p_user_id: userId,
+      p_content: newContent,
+      p_current_version: pairNode.version,
     });
-    await this.pairNodeRepo.updateSelectMessage(pairNodeId, newMessage.id, pairNode.version);
-    return newMessage;
+
+    if (error) {
+      if (error.message.includes('concurrency_conflict')) throw new ConcurrencyError();
+      throw new InfrastructureError(`rethink_pair_node RPC エラー: ${error.message}`);
+    }
   }
 }

--- a/src/application/usecases/SaveChatMessageUseCase.ts
+++ b/src/application/usecases/SaveChatMessageUseCase.ts
@@ -45,7 +45,7 @@ export class SaveChatMessageUseCase {
       }),
     ]);
 
-    await this.pairNodeRepo.updateSelectMessage(pairNode.id, assistantMessage.id);
+    await this.pairNodeRepo.updateSelectMessage(pairNode.id, assistantMessage.id, pairNode.version);
 
     return { pairNodeId: pairNode.id };
   }

--- a/src/container/createUseCases.ts
+++ b/src/container/createUseCases.ts
@@ -79,8 +79,8 @@ export function createSaveChatMessageUseCase(supabase: SupabaseClient) {
 }
 
 export function createRethinkMessageUseCase(supabase: SupabaseClient) {
-  const { pairNode, message } = createRepositories(supabase);
-  return new RethinkMessageUseCase(pairNode, message);
+  const { pairNode } = createRepositories(supabase);
+  return new RethinkMessageUseCase(pairNode, supabase);
 }
 
 export function createCheckDbLimitsUseCase(): CheckDbLimitsUseCase {

--- a/src/core/domains/chat/IPairNodeRepository.ts
+++ b/src/core/domains/chat/IPairNodeRepository.ts
@@ -2,6 +2,7 @@ import type { PairNodeData } from './PairNode';
 
 export interface IPairNodeRepository {
   findByThread(threadId: string): Promise<PairNodeData[]>;
+  findById(pairNodeId: string): Promise<PairNodeData | null>;
   save(userId: string, threadId: string): Promise<PairNodeData>;
-  updateSelectMessage(pairNodeId: string, messageId: string): Promise<void>;
+  updateSelectMessage(pairNodeId: string, messageId: string, currentVersion: number): Promise<void>;
 }

--- a/src/core/domains/chat/PairNode.ts
+++ b/src/core/domains/chat/PairNode.ts
@@ -4,4 +4,5 @@ export interface PairNodeData {
   threadId: string;
   selectMessageId: string | null;
   createdAt: string;
+  version: number;
 }

--- a/src/core/errors/ConcurrencyError.ts
+++ b/src/core/errors/ConcurrencyError.ts
@@ -1,0 +1,6 @@
+export class ConcurrencyError extends Error {
+  constructor(message = '競合が発生しました。再試行してください。') {
+    super(message);
+    this.name = 'ConcurrencyError';
+  }
+}

--- a/src/infrastructure/jobs/InMemoryQueue.ts
+++ b/src/infrastructure/jobs/InMemoryQueue.ts
@@ -5,6 +5,9 @@ type JobHandler = (payload: Record<string, unknown>) => Promise<void>;
 
 // MVP: fire-and-forget (Next.js 環境で動く最小実装)
 // 本番: RedisQueue / BullMQ に差し替え可能
+// NOTE: Cloudflare Workers isolates context per request.
+// Handlers registered via register() do not persist across requests.
+// For production on Cloudflare, replace with a durable queue (e.g., Cloudflare Queues, BullMQ + Redis).
 export class InMemoryQueue implements IJobQueue {
   private handlers = new Map<string, JobHandler>();
 

--- a/src/infrastructure/rate-limiting/InMemorySlidingWindowRateLimiter.ts
+++ b/src/infrastructure/rate-limiting/InMemorySlidingWindowRateLimiter.ts
@@ -32,6 +32,29 @@ export class InMemorySlidingWindowRateLimiter implements ILLMRateLimiter {
     this.windows.set(userId, entries);
   }
 
+  async checkAndRecord(userId: string, tokens: number): Promise<RateLimitStatus> {
+    const now = Date.now();
+    const entries = this.getActiveEntries(userId, now);
+    const usedTokens = entries.reduce((sum, e) => sum + e.tokens, 0);
+    const allowed = usedTokens < this.maxTokens;
+    const oldest = entries[0]?.timestamp ?? now;
+    const resetAtMs = oldest + this.windowMs;
+
+    if (allowed) {
+      entries.push({ timestamp: now, tokens });
+      this.windows.set(userId, entries);
+    }
+
+    return {
+      allowed,
+      usedTokens: allowed ? usedTokens + tokens : usedTokens,
+      maxTokens: this.maxTokens,
+      remainingTokens: Math.max(0, this.maxTokens - usedTokens - (allowed ? tokens : 0)),
+      resetAtMs,
+      retryAfterSeconds: allowed ? 0 : Math.ceil((resetAtMs - now) / 1000),
+    };
+  }
+
   private getActiveEntries(userId: string, now: number) {
     const windowStart = now - this.windowMs;
     const all = this.windows.get(userId) ?? [];

--- a/src/infrastructure/rate-limiting/InMemorySlidingWindowRateLimiter.ts
+++ b/src/infrastructure/rate-limiting/InMemorySlidingWindowRateLimiter.ts
@@ -8,7 +8,7 @@ export class InMemorySlidingWindowRateLimiter implements ILLMRateLimiter {
     private readonly windowMs: number,
   ) {}
 
-  check(userId: string): RateLimitStatus {
+  async check(userId: string): Promise<RateLimitStatus> {
     const now = Date.now();
     const entries = this.getActiveEntries(userId, now);
     const usedTokens = entries.reduce((sum, e) => sum + e.tokens, 0);
@@ -25,7 +25,7 @@ export class InMemorySlidingWindowRateLimiter implements ILLMRateLimiter {
     };
   }
 
-  record(userId: string, tokens: number): void {
+  async record(userId: string, tokens: number): Promise<void> {
     const now = Date.now();
     const entries = this.getActiveEntries(userId, now);
     entries.push({ timestamp: now, tokens });

--- a/src/infrastructure/rate-limiting/SupabaseSlidingWindowRateLimiter.ts
+++ b/src/infrastructure/rate-limiting/SupabaseSlidingWindowRateLimiter.ts
@@ -1,0 +1,68 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { ILLMRateLimiter, RateLimitStatus } from '@/application/ports/ILLMRateLimiter';
+
+export class SupabaseSlidingWindowRateLimiter implements ILLMRateLimiter {
+  constructor(
+    private readonly supabase: SupabaseClient,
+    private readonly maxTokens: number,
+    private readonly windowMs: number,
+  ) {}
+
+  async check(userId: string): Promise<RateLimitStatus> {
+    const now = Date.now();
+    const windowStart = new Date(now - this.windowMs).toISOString();
+
+    const { data, error } = await this.supabase
+      .from('token_usage_windows')
+      .select('used_tokens, window_start')
+      .eq('user_id', userId)
+      .gte('window_start', windowStart)
+      .order('window_start', { ascending: true });
+
+    if (error) {
+      // On DB error, fail open to avoid blocking users
+      return {
+        allowed: true,
+        usedTokens: 0,
+        maxTokens: this.maxTokens,
+        remainingTokens: this.maxTokens,
+        resetAtMs: now + this.windowMs,
+        retryAfterSeconds: 0,
+      };
+    }
+
+    const rows = data ?? [];
+    const usedTokens = rows.reduce((sum, r) => sum + (r.used_tokens as number), 0);
+    const allowed = usedTokens < this.maxTokens;
+    const oldestMs = rows.length > 0
+      ? new Date(rows[0].window_start as string).getTime()
+      : now;
+    const resetAtMs = oldestMs + this.windowMs;
+
+    return {
+      allowed,
+      usedTokens,
+      maxTokens: this.maxTokens,
+      remainingTokens: Math.max(0, this.maxTokens - usedTokens),
+      resetAtMs,
+      retryAfterSeconds: allowed ? 0 : Math.ceil((resetAtMs - now) / 1000),
+    };
+  }
+
+  async record(userId: string, tokens: number): Promise<void> {
+    const now = new Date().toISOString();
+    await this.supabase.from('token_usage_windows').insert({
+      user_id: userId,
+      window_start: now,
+      used_tokens: tokens,
+    });
+
+    // Clean up expired entries (fire-and-forget)
+    const expiredBefore = new Date(Date.now() - this.windowMs).toISOString();
+    void this.supabase
+      .from('token_usage_windows')
+      .delete()
+      .eq('user_id', userId)
+      .lt('window_start', expiredBefore);
+  }
+}

--- a/src/infrastructure/rate-limiting/SupabaseSlidingWindowRateLimiter.ts
+++ b/src/infrastructure/rate-limiting/SupabaseSlidingWindowRateLimiter.ts
@@ -68,13 +68,61 @@ export class SupabaseSlidingWindowRateLimiter implements ILLMRateLimiter {
       window_start: now,
       used_tokens: tokens,
     });
+  }
 
-    // Clean up expired entries (fire-and-forget)
+  async cleanup(userId: string): Promise<void> {
     const expiredBefore = new Date(Date.now() - this.windowMs).toISOString();
-    void this.supabase
+    await this.supabase
       .from('token_usage_windows')
       .delete()
       .eq('user_id', userId)
       .lt('window_start', expiredBefore);
+  }
+
+  async checkAndRecord(userId: string, tokens: number): Promise<RateLimitStatus> {
+    const now = Date.now();
+
+    const { data, error } = await this.supabase.rpc('check_and_record_tokens', {
+      p_user_id: userId,
+      p_tokens: tokens,
+      p_max_tokens: this.maxTokens,
+      p_window_ms: this.windowMs,
+    });
+
+    if (error || data == null) {
+      return {
+        allowed: false,
+        usedTokens: 0,
+        maxTokens: this.maxTokens,
+        remainingTokens: 0,
+        resetAtMs: now + this.windowMs,
+        retryAfterSeconds: Math.ceil(this.windowMs / 1000),
+      };
+    }
+
+    const allowed = data.allowed as boolean;
+    const usedTokens = Number(data.usedTokens);
+    const oldestMs = data.oldestWindowStart
+      ? new Date(data.oldestWindowStart as string).getTime()
+      : now;
+    const resetAtMs = oldestMs + this.windowMs;
+
+    if (allowed) {
+      const expiredBefore = new Date(now - this.windowMs).toISOString();
+      void this.supabase
+        .from('token_usage_windows')
+        .delete()
+        .eq('user_id', userId)
+        .lt('window_start', expiredBefore);
+    }
+
+    return {
+      allowed,
+      usedTokens,
+      maxTokens: this.maxTokens,
+      remainingTokens: Math.max(0, this.maxTokens - usedTokens),
+      resetAtMs,
+      retryAfterSeconds: allowed ? 0 : Math.ceil((resetAtMs - now) / 1000),
+    };
   }
 }

--- a/src/infrastructure/rate-limiting/SupabaseSlidingWindowRateLimiter.ts
+++ b/src/infrastructure/rate-limiting/SupabaseSlidingWindowRateLimiter.ts
@@ -12,15 +12,27 @@ export class SupabaseSlidingWindowRateLimiter implements ILLMRateLimiter {
     const now = Date.now();
     const windowStart = new Date(now - this.windowMs).toISOString();
 
-    const { data, error } = await this.supabase
-      .from('token_usage_windows')
-      .select('used_tokens, window_start')
-      .eq('user_id', userId)
-      .gte('window_start', windowStart)
-      .order('window_start', { ascending: true });
+    const { data, error } = await this.supabase.rpc('get_token_usage_in_window', {
+      p_user_id: userId,
+      p_window_start: windowStart,
+    });
 
     if (error) {
-      // On DB error, fail open to avoid blocking users
+      console.error('[RateLimiter] check() DB error — failing closed', {
+        userId,
+        error: error.message,
+      });
+      return {
+        allowed: false,
+        usedTokens: this.maxTokens,
+        maxTokens: this.maxTokens,
+        remainingTokens: 0,
+        resetAtMs: now + this.windowMs,
+        retryAfterSeconds: Math.ceil(this.windowMs / 1000),
+      };
+    }
+
+    if (!data || data.length === 0) {
       return {
         allowed: true,
         usedTokens: 0,
@@ -31,11 +43,11 @@ export class SupabaseSlidingWindowRateLimiter implements ILLMRateLimiter {
       };
     }
 
-    const rows = data ?? [];
-    const usedTokens = rows.reduce((sum, r) => sum + (r.used_tokens as number), 0);
+    const { total_used, oldest_window_start } = data[0];
+    const usedTokens = Number(total_used);
     const allowed = usedTokens < this.maxTokens;
-    const oldestMs = rows.length > 0
-      ? new Date(rows[0].window_start as string).getTime()
+    const oldestMs = oldest_window_start
+      ? new Date(oldest_window_start).getTime()
       : now;
     const resetAtMs = oldestMs + this.windowMs;
 

--- a/src/infrastructure/rate-limiting/rateLimiterSingleton.ts
+++ b/src/infrastructure/rate-limiting/rateLimiterSingleton.ts
@@ -1,6 +1,17 @@
-import { InMemorySlidingWindowRateLimiter } from './InMemorySlidingWindowRateLimiter';
+import { createClient } from '@supabase/supabase-js';
+import { SupabaseSlidingWindowRateLimiter } from './SupabaseSlidingWindowRateLimiter';
 
-export const chatRateLimiter = new InMemorySlidingWindowRateLimiter(
-  parseInt(process.env.CHAT_RATE_LIMIT_MAX_TOKENS ?? '50000', 10),
-  parseInt(process.env.CHAT_RATE_LIMIT_WINDOW_MS ?? String(60 * 60 * 1000), 10),
-);
+// Factory function: creates a new instance per invocation.
+// Cloudflare Workers isolates context per request — module-level singletons
+// do not persist across requests, so we use a factory instead.
+export function createChatRateLimiter() {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+  return new SupabaseSlidingWindowRateLimiter(
+    supabase,
+    parseInt(process.env.CHAT_RATE_LIMIT_MAX_TOKENS ?? '50000', 10),
+    parseInt(process.env.CHAT_RATE_LIMIT_WINDOW_MS ?? String(60 * 60 * 1000), 10),
+  );
+}

--- a/src/infrastructure/rate-limiting/rateLimiterSingleton.ts
+++ b/src/infrastructure/rate-limiting/rateLimiterSingleton.ts
@@ -1,17 +1,31 @@
 import { createClient } from '@supabase/supabase-js';
 import { SupabaseSlidingWindowRateLimiter } from './SupabaseSlidingWindowRateLimiter';
 
+function getRequiredEnvVar(name: string): string {
+  const value = process.env[name];
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function getPositiveIntegerEnvVar(name: string, fallback: number): number {
+  const rawValue = process.env[name];
+  const parsed = Number.parseInt(rawValue ?? String(fallback), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid environment variable ${name}: expected positive integer, got "${rawValue}"`);
+  }
+  return parsed;
+}
+
 // Factory function: creates a new instance per invocation.
 // Cloudflare Workers isolates context per request — module-level singletons
 // do not persist across requests, so we use a factory instead.
 export function createChatRateLimiter() {
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  );
-  return new SupabaseSlidingWindowRateLimiter(
-    supabase,
-    parseInt(process.env.CHAT_RATE_LIMIT_MAX_TOKENS ?? '50000', 10),
-    parseInt(process.env.CHAT_RATE_LIMIT_WINDOW_MS ?? String(60 * 60 * 1000), 10),
-  );
+  const supabaseUrl = getRequiredEnvVar('NEXT_PUBLIC_SUPABASE_URL');
+  const serviceRoleKey = getRequiredEnvVar('SUPABASE_SERVICE_ROLE_KEY');
+  const maxTokens = getPositiveIntegerEnvVar('CHAT_RATE_LIMIT_MAX_TOKENS', 50000);
+  const windowMs = getPositiveIntegerEnvVar('CHAT_RATE_LIMIT_WINDOW_MS', 60 * 60 * 1000);
+  const supabase = createClient(supabaseUrl, serviceRoleKey);
+  return new SupabaseSlidingWindowRateLimiter(supabase, maxTokens, windowMs);
 }

--- a/src/infrastructure/repositories/SupabasePairNodeRepository.ts
+++ b/src/infrastructure/repositories/SupabasePairNodeRepository.ts
@@ -3,6 +3,7 @@ import type { IPairNodeRepository } from '@/core/domains/chat/IPairNodeRepositor
 import type { PairNodeData } from '@/core/domains/chat/PairNode';
 import { PairNodeMapper } from '@/application/mappers/PairNodeMapper';
 import { InfrastructureError } from '@/core/errors/InfrastructureError';
+import { ConcurrencyError } from '@/core/errors/ConcurrencyError';
 
 export class SupabasePairNodeRepository implements IPairNodeRepository {
   constructor(private supabase: SupabaseClient) {}
@@ -29,12 +30,29 @@ export class SupabasePairNodeRepository implements IPairNodeRepository {
     return PairNodeMapper.fromRow(data as Record<string, unknown>);
   }
 
-  async updateSelectMessage(pairNodeId: string, messageId: string): Promise<void> {
-    const { error } = await this.supabase
+  async findById(pairNodeId: string): Promise<PairNodeData | null> {
+    const { data, error } = await this.supabase
       .from('pair_nodes')
-      .update({ select_message_id: messageId })
-      .eq('id', pairNodeId);
+      .select('*')
+      .eq('id', pairNodeId)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') return null;
+      throw new InfrastructureError(`ペアノード取得エラー: ${error.message}`);
+    }
+    return data ? PairNodeMapper.fromRow(data as Record<string, unknown>) : null;
+  }
+
+  async updateSelectMessage(pairNodeId: string, messageId: string, currentVersion: number): Promise<void> {
+    const { data, error } = await this.supabase
+      .from('pair_nodes')
+      .update({ select_message_id: messageId, version: currentVersion + 1 })
+      .eq('id', pairNodeId)
+      .eq('version', currentVersion)
+      .select('id');
 
     if (error) throw new InfrastructureError(`ペアノード更新エラー: ${error.message}`);
+    if (!data || data.length === 0) throw new ConcurrencyError();
   }
 }

--- a/supabase/migrations/021_add_version_to_pair_node.sql
+++ b/supabase/migrations/021_add_version_to_pair_node.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pair_nodes ADD COLUMN IF NOT EXISTS version integer NOT NULL DEFAULT 0;

--- a/supabase/migrations/022_token_usage_windows.sql
+++ b/supabase/migrations/022_token_usage_windows.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS token_usage_windows (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  window_start timestamptz NOT NULL,
+  used_tokens integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_token_usage_windows_user_id ON token_usage_windows(user_id);
+CREATE INDEX IF NOT EXISTS idx_token_usage_windows_window_start ON token_usage_windows(window_start);
+
+ALTER TABLE token_usage_windows ENABLE ROW LEVEL SECURITY;
+
+-- Only service_role can access (rate limiter runs server-side with service role key)
+CREATE POLICY "service_role_only" ON token_usage_windows
+  FOR ALL TO service_role USING (true) WITH CHECK (true);

--- a/supabase/migrations/023_rate_limiter_aggregate_rpc.sql
+++ b/supabase/migrations/023_rate_limiter_aggregate_rpc.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE FUNCTION get_token_usage_in_window(
+  p_user_id uuid,
+  p_window_start timestamptz
+)
+RETURNS TABLE(total_used bigint, oldest_window_start timestamptz)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  SELECT
+    COALESCE(SUM(used_tokens), 0) AS total_used,
+    MIN(window_start) AS oldest_window_start
+  FROM token_usage_windows
+  WHERE user_id = p_user_id
+    AND window_start >= p_window_start;
+$$;

--- a/supabase/migrations/024_fix_rate_limiter_indexes.sql
+++ b/supabase/migrations/024_fix_rate_limiter_indexes.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_token_usage_windows_user_id;
+DROP INDEX IF EXISTS idx_token_usage_windows_window_start;
+
+CREATE INDEX IF NOT EXISTS idx_token_usage_windows_user_window
+  ON token_usage_windows(user_id, window_start);

--- a/supabase/migrations/025_rethink_atomic_rpc.sql
+++ b/supabase/migrations/025_rethink_atomic_rpc.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE FUNCTION rethink_pair_node(
+  p_pair_node_id uuid,
+  p_user_id uuid,
+  p_content text,
+  p_current_version integer
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_new_message_id uuid;
+  v_rows_updated integer;
+BEGIN
+  -- Insert new assistant message
+  INSERT INTO messages (pair_node_id, user_id, role, content)
+  VALUES (p_pair_node_id, p_user_id, 'assistant', p_content)
+  RETURNING id INTO v_new_message_id;
+
+  -- OCC update: only succeeds if version matches
+  UPDATE pair_nodes
+  SET select_message_id = v_new_message_id,
+      version = p_current_version + 1
+  WHERE id = p_pair_node_id
+    AND version = p_current_version;
+
+  GET DIAGNOSTICS v_rows_updated = ROW_COUNT;
+
+  IF v_rows_updated = 0 THEN
+    -- Version mismatch: rollback the message insert and signal conflict
+    RAISE EXCEPTION 'concurrency_conflict' USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN jsonb_build_object('messageId', v_new_message_id);
+END;
+$$;

--- a/supabase/migrations/026_check_and_record_token_rpc.sql
+++ b/supabase/migrations/026_check_and_record_token_rpc.sql
@@ -1,0 +1,42 @@
+CREATE OR REPLACE FUNCTION check_and_record_tokens(
+  p_user_id uuid,
+  p_tokens integer,
+  p_max_tokens integer,
+  p_window_ms bigint
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_window_start timestamptz := now() - (p_window_ms || ' milliseconds')::interval;
+  v_used bigint;
+  v_oldest timestamptz;
+BEGIN
+  -- Lock the user's rows to prevent concurrent over-spend
+  SELECT COALESCE(SUM(used_tokens), 0), MIN(window_start)
+  INTO v_used, v_oldest
+  FROM token_usage_windows
+  WHERE user_id = p_user_id
+    AND window_start >= v_window_start
+  FOR UPDATE;
+
+  IF v_used >= p_max_tokens THEN
+    RETURN jsonb_build_object(
+      'allowed', false,
+      'usedTokens', v_used,
+      'oldestWindowStart', v_oldest
+    );
+  END IF;
+
+  -- Under budget: record usage atomically
+  INSERT INTO token_usage_windows(user_id, window_start, used_tokens)
+  VALUES (p_user_id, now(), p_tokens);
+
+  RETURN jsonb_build_object(
+    'allowed', true,
+    'usedTokens', v_used + p_tokens,
+    'oldestWindowStart', v_oldest
+  );
+END;
+$$;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -34,5 +34,12 @@
 			"id": "3194659df99e40e9a561e94fe57755b0",
 			"preview_id": "ec9c007488be4477a1de8bb751815a94"
 		}
-	]
+	],
+	// Smart placement: automatically routes Worker invocations to the CF region nearest
+	// to the origin database, minimizing round-trip latency between the Worker and Supabase.
+	// Set your Supabase project region to ap-northeast-1 (Tokyo) or whichever region is
+	// closest to your primary user base for best results.
+	"smart_placement": {
+		"mode": "smart"
+	}
 }


### PR DESCRIPTION
## Summary

- **#19**: インメモリ Rate Limiter を Supabase 永続実装 (`SupabaseSlidingWindowRateLimiter`) に置換。CF Workers のリクエスト分離問題を解決。`ILLMRateLimiter` インターフェースを async 化し、コールサイト全体を更新
- **#20**: `wrangler.jsonc` に `smart_placement: { mode: "smart" }` を追加。README にリージョン整合ガイドを追記。`docs/DEPLOYMENT_CHECKLIST.md` を新規作成
- **#21**: `app/api/chat/rethink/route.ts` の 6 DB クエリ（getMessages / getLatest / findRecent / getBigFive / getAttachment / getIdentityStatus）を単一 `Promise.all` に集約し直列→並列化
- **#22**: `pair_nodes` テーブルに `version` カラムを追加（migration 021）。`findById` + OCC 付き `updateSelectMessage` を実装。競合時は `ConcurrencyError` → HTTP 409
- **#23**: `app/dashboard/page.tsx` のトップレベル await を `DashboardContent.tsx` 子コンポーネントに移動し `<Suspense>` でラップ。HTML ストリーミングをアンブロック

## Migrations

| ファイル | 内容 |
|---|---|
| `021_add_version_to_pair_node.sql` | `pair_nodes.version integer NOT NULL DEFAULT 0` 追加 |
| `022_token_usage_windows.sql` | `token_usage_windows` テーブル作成（Supabase Rate Limiter 用） |

## Test plan

- [ ] `npx tsc --noEmit` — エラーなし確認済み
- [ ] `npm run lint` — 警告・エラーなし確認済み
- [ ] `supabase db push` で migration 021・022 を適用
- [ ] `/api/chat` でレート制限が Supabase に記録されることを確認
- [ ] `/api/chat/rethink` を同時 2 リクエスト送信し 409 が返ることを確認
- [ ] ダッシュボードページが HTML を即座にストリームし、チャート部分が遅延ロードされることを確認

Closes #19, Closes #20, Closes #21, Closes #22, Closes #23